### PR TITLE
feat: update documentation to be more accurate and add embed config

### DIFF
--- a/Embed.toml
+++ b/Embed.toml
@@ -1,0 +1,2 @@
+[default.general]
+chip = "R7FA4M1AB"

--- a/README.md
+++ b/README.md
@@ -46,14 +46,15 @@ You can find this information in the data sheet or the reference manual of your
 device.
 
 In this example we'll be using the STM32F3DISCOVERY. This board contains an
-STM32F303VCT6 microcontroller. This microcontroller has:
+R7FA4M1AB microcontroller. This microcontroller has:
 
 - A Cortex-M4F core that includes a single precision FPU
 
-- 256 KiB of Flash located at address 0x0800_0000.
+- 256 KiB of Flash located at address 0x00004000.
 
-- 40 KiB of RAM located at address 0x2000_0000. (There's another RAM region but
-  for simplicity we'll ignore it).
+- 32 KiB of RAM located at address 0x2000_0000.
+
+- 8 KiB of Data Flash located at address 0x0x40100000
 
 1. Instantiate the template.
 
@@ -67,7 +68,7 @@ $ cd app
 ```
 
 2. Set a default compilation target. There are four options as mentioned at the
-   bottom of `.cargo/config`. For the STM32F303VCT6, which has a Cortex-M4F
+   bottom of `.cargo/config`. For the R7FA4M1AB, which has a Cortex-M4F
    core, we'll pick the `thumbv7em-none-eabihf` target.
 
 ``` console
@@ -90,12 +91,13 @@ target = "thumbv7em-none-eabihf" # Cortex-M4F and Cortex-M7F (with FPU)
 
 ``` console
 $ cat memory.x
-/* Linker script for the STM32F303VCT6 */
+/* Linker script for the R7FA4M1AB */
 MEMORY
 {
   /* NOTE 1 K = 1 KiBi = 1024 bytes */
-  FLASH : ORIGIN = 0x08000000, LENGTH = 256K
-  RAM : ORIGIN = 0x20000000, LENGTH = 40K
+  FLASH(rx) : ORIGIN = 0x00004000, LENGTH = 256k
+  RAM(rwx)  : ORIGIN = 0x20000000, LENGTH = 32k
+  DFLASH(r)  : ORIGIN = 0x40100000, LENGTH = 8k
 }
 ```
 
@@ -103,6 +105,12 @@ MEMORY
 
 ``` console
 $ cargo build
+```
+
+5. Uploading the template to your board
+
+``` console
+$ cargo embed
 ```
 
 ## VS Code


### PR DESCRIPTION
Update the documentation to use information from the chip that is actually on the Arduino Uno R4.

Also add an `Embed.toml` to make it easier to upload the code to the Arduino.

P.S. This repo was incredibly helpful to get me started! I super appreciate the work that you have done here. Let me know if there is any other way that I can support this.